### PR TITLE
Fix ticker retrieval in paper trade execution

### DIFF
--- a/gemVPS/src/execution/trade_executor.py
+++ b/gemVPS/src/execution/trade_executor.py
@@ -72,7 +72,8 @@ class TradeExecutor:
             
             try:
                 # 1. Fetch live price to make the simulation realistic
-                price = await self.exchange.fetch_ticker(market_symbol)['last']
+                ticker = await self.exchange.fetch_ticker(market_symbol)
+                price = ticker.get("last")
                 if not price:
                     logger.error(f"[PAPER TRADE] Could not fetch live price for {market_symbol}. Aborting.")
                     return


### PR DESCRIPTION
## Summary
- handle ticker result before parsing price when executing paper trades

## Testing
- `python -m py_compile src/execution/trade_executor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791f647f04832bbc45061373bf60dd