### PR TITLE
Fix VCWatcher initialization

### DIFF
--- a/gemVPS/src/main.py
+++ b/gemVPS/src/main.py
@@ -40,7 +40,7 @@ async def main(config: Settings):
         # Each module is instantiated with the components it needs to interact with.
         modules = {
             "whale_watcher": AdvancedWhaleWatcher(config, db_manager, signal_aggregator, telegram_bot),
-            "vc_watcher": VCWatcher(config, signal_aggregator, db_manager),
+            "vc_watcher": VCWatcher(config, signal_aggregator),
             "gas_analyzer": GasAnalyzer(config, signal_aggregator),
             "cex_scanner": CEXListingScanner(config, signal_aggregator),
             "stablecoin_monitor": StablecoinMonitor(config, signal_aggregator),


### PR DESCRIPTION
## Summary
- update module initialization args for VCWatcher

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687975332da4832b8846b94557506d66